### PR TITLE
Gerenciar perguntas de português e sistema de patentes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1802,7 +1802,7 @@
                     <div id="stats-container">
                         <!-- Player Level Summary -->
                         <div class="stats-summary">
-                            <h4>🏆 SEU NÍVEL</h4>
+                            <h4>🏆 SUA PATENTE</h4>
                             <div class="level-badge" id="levelBadge">Iniciante</div>
                             <div class="xp-bar">
                                 <div class="xp-fill" id="xpFill" style="width: 0%"></div>
@@ -2459,45 +2459,37 @@
         }
 
         // CALCULATE LEVEL AND XP
-        function calculateLevel(totalScore) {
-            const levels = [
-                { min: 0, max: 99, name: 'Iniciante', color: '#888888' },
-                { min: 100, max: 299, name: 'Aprendiz', color: '#00FF88' },
-                { min: 300, max: 599, name: 'Estudante', color: '#00BFFF' },
-                { min: 600, max: 999, name: 'Competente', color: '#FFFF00' },
-                { min: 1000, max: 1499, name: 'Avançado', color: '#FF6B35' },
-                { min: 1500, max: 2499, name: 'Expert', color: '#FF0080' },
-                { min: 2500, max: 3999, name: 'Mestre', color: '#9400D3' },
-                { min: 4000, max: 5999, name: 'Grão-Mestre', color: '#FFD700' },
-                { min: 6000, max: 9999, name: 'Lendário', color: '#FF1493' },
-                { min: 10000, max: Infinity, name: 'Mítico', color: '#00FFFF' }
-            ];
-            
-            for (let level of levels) {
-                if (totalScore >= level.min && totalScore <= level.max) {
-                    const xpInLevel = totalScore - level.min;
-                    const xpNeeded = level.max - level.min + 1;
-                    const progress = Math.min(100, (xpInLevel / xpNeeded) * 100);
-                    
-                    return {
-                        name: level.name,
-                        color: level.color,
-                        xp: xpInLevel,
-                        xpNeeded: xpNeeded,
-                        progress: progress,
-                        totalScore: totalScore
-                    };
-                }
-            }
-            
-            return {
-                name: 'Iniciante',
-                color: '#888888',
-                xp: 0,
-                xpNeeded: 100,
-                progress: 0,
-                totalScore: 0
-            };
+        // Free Fire ranks mapping (rank up every 100 XP)
+        const FREE_FIRE_RANKS = [
+            { name: 'Bronze I', color: '#9E7B4F' },
+            { name: 'Bronze II', color: '#9E7B4F' },
+            { name: 'Bronze III', color: '#9E7B4F' },
+            { name: 'Prata I', color: '#C0C0C0' },
+            { name: 'Prata II', color: '#C0C0C0' },
+            { name: 'Prata III', color: '#C0C0C0' },
+            { name: 'Ouro I', color: '#FFD700' },
+            { name: 'Ouro II', color: '#FFD700' },
+            { name: 'Ouro III', color: '#FFD700' },
+            { name: 'Ouro IV', color: '#FFD700' },
+            { name: 'Platina I', color: '#00BFFF' },
+            { name: 'Platina II', color: '#00BFFF' },
+            { name: 'Platina III', color: '#00BFFF' },
+            { name: 'Platina IV', color: '#00BFFF' },
+            { name: 'Diamante I', color: '#7DF9FF' },
+            { name: 'Diamante II', color: '#7DF9FF' },
+            { name: 'Diamante III', color: '#7DF9FF' },
+            { name: 'Diamante IV', color: '#7DF9FF' },
+            { name: 'Mestre', color: '#FF6B35' },
+            { name: 'Desafiante', color: '#FF1493' }
+        ];
+
+        function calculateLevelFromXP(xp) {
+            const rankIndex = Math.min(Math.floor((xp || 0) / 100), FREE_FIRE_RANKS.length - 1);
+            const rank = FREE_FIRE_RANKS[rankIndex];
+            const xpInLevel = (xp || 0) % 100;
+            const xpNeeded = 100;
+            const progress = Math.min(100, (xpInLevel / xpNeeded) * 100);
+            return { name: rank.name, color: rank.color, xp: xpInLevel, xpNeeded, progress, totalScore: xp || 0 };
         }
 
         // CHECK FOR ACHIEVEMENTS
@@ -2592,7 +2584,8 @@
                 }
 
                 // Update Level and XP
-                const levelInfo = calculateLevel(data.totalScore || 0);
+                // Prefer stats.xp, fallback to totalScore for backward compatibility
+                const levelInfo = calculateLevelFromXP((data.xp != null ? data.xp : (data.totalScore || 0)));
                 const levelBadge = document.getElementById('levelBadge');
                 const xpFill = document.getElementById('xpFill');
                 const xpText = document.getElementById('xpText');

--- a/quiz/portugues/index.html
+++ b/quiz/portugues/index.html
@@ -249,6 +249,30 @@
             try { const raw = localStorage.getItem('saebStats'); return raw ? JSON.parse(raw) : {}; } catch(e){ return {}; }
         }
         function saveStats(stats) { try { localStorage.setItem('saebStats', JSON.stringify(stats)); } catch(e){} }
+
+        // Free Fire ranks and XP management
+        const FREE_FIRE_RANKS = [
+            'Bronze I','Bronze II','Bronze III',
+            'Prata I','Prata II','Prata III',
+            'Ouro I','Ouro II','Ouro III','Ouro IV',
+            'Platina I','Platina II','Platina III','Platina IV',
+            'Diamante I','Diamante II','Diamante III','Diamante IV',
+            'Mestre','Desafiante'
+        ];
+
+        function updateRankingByXP(stats) {
+            const currentXP = stats.xp || 0;
+            const rankIndex = Math.min(Math.floor(currentXP / 100), FREE_FIRE_RANKS.length - 1);
+            stats.ranking = FREE_FIRE_RANKS[rankIndex];
+        }
+
+        function addXP(amount) {
+            const stats = loadStats();
+            stats.xp = (stats.xp || 0) + amount;
+            stats.totalScore = (stats.totalScore || 0) + amount; // compatibilidade
+            updateRankingByXP(stats);
+            saveStats(stats);
+        }
         function updateStatsAfterQuiz(finalCorrect, totalQuestions, elapsedMinutes) {
             const stats = loadStats();
             stats.quizzesCompleted = (stats.quizzesCompleted || 0) + 1;
@@ -262,11 +286,7 @@
             stats.currentStreak = passed ? (stats.currentStreak || 0) + 1 : 0;
             stats.bestStreak = Math.max(stats.bestStreak || 0, stats.currentStreak);
 
-            const overallPct = Math.round((stats.overallCorrect || 0) / Math.max(1, (stats.overallTotal || 0)) * 100);
-            if (overallPct >= 90) stats.ranking = 'Lendário';
-            else if (overallPct >= 75) stats.ranking = 'Pro';
-            else if (overallPct >= 50) stats.ranking = 'Intermediário';
-            else stats.ranking = 'Iniciante';
+            updateRankingByXP(stats);
 
             saveStats(stats);
         }
@@ -274,7 +294,13 @@
         function goToLobby() { window.location.href = '/index.html#lobby'; }
 
         function initQuiz() {
-            selectedQuestions = getRandomQuestions(questions, 10);
+            // Filtrar questões que dependem de texto base
+            const TEXT_BASED_REGEX = /(texto|tirinha)/i;
+            let pool = questions.filter(q => !TEXT_BASED_REGEX.test(q.question || ''));
+            if (pool.length < 10) {
+                pool = questions.slice();
+            }
+            selectedQuestions = getRandomQuestions(pool, 10);
             currentQuestionIndex = 0; score = 0; selectedAnswer = null; startTime = Date.now(); answered = false;
             createParticles();
             showQuestion();
@@ -338,7 +364,7 @@
                 if (idx === q.correct) alt.classList.add('correct');
                 else if (idx === selectedAnswer && !isCorrect) alt.classList.add('incorrect');
             });
-            if (isCorrect) { score++; document.getElementById('scoreDisplay').textContent = `ACERTOS: ${score}`; }
+            if (isCorrect) { score++; document.getElementById('scoreDisplay').textContent = `ACERTOS: ${score}`; addXP(50); }
             setTimeout(() => showFeedbackModal(isCorrect, q), 900);
         }
 

--- a/quiz_matematica.html
+++ b/quiz_matematica.html
@@ -1045,6 +1045,31 @@
             }
         }
 
+        // Free Fire rank mapping and XP helpers
+        const FREE_FIRE_RANKS = [
+            'Bronze I','Bronze II','Bronze III',
+            'Prata I','Prata II','Prata III',
+            'Ouro I','Ouro II','Ouro III','Ouro IV',
+            'Platina I','Platina II','Platina III','Platina IV',
+            'Diamante I','Diamante II','Diamante III','Diamante IV',
+            'Mestre','Desafiante'
+        ];
+
+        function updateRankingByXP(stats) {
+            const currentXP = stats.xp || 0;
+            const rankIndex = Math.min(Math.floor(currentXP / 100), FREE_FIRE_RANKS.length - 1);
+            stats.ranking = FREE_FIRE_RANKS[rankIndex];
+        }
+
+        function addXP(amount) {
+            const stats = loadStats();
+            stats.xp = (stats.xp || 0) + amount;
+            // Manter compatibilidade com UI antiga que usa totalScore
+            stats.totalScore = (stats.totalScore || 0) + amount;
+            updateRankingByXP(stats);
+            saveStats(stats);
+        }
+
         function updateStatsAfterQuiz(finalCorrect, totalQuestions, elapsedMinutes) {
             const stats = loadStats();
             stats.quizzesCompleted = (stats.quizzesCompleted || 0) + 1;
@@ -1059,12 +1084,8 @@
             stats.currentStreak = passed ? (stats.currentStreak || 0) + 1 : 0;
             stats.bestStreak = Math.max(stats.bestStreak || 0, stats.currentStreak);
 
-            // ranking simples
-            const overallPct = Math.round((stats.overallCorrect || 0) / Math.max(1, (stats.overallTotal || 0)) * 100);
-            if (overallPct >= 90) stats.ranking = 'Lendário';
-            else if (overallPct >= 75) stats.ranking = 'Pro';
-            else if (overallPct >= 50) stats.ranking = 'Intermediário';
-            else stats.ranking = 'Iniciante';
+            // Atualizar patente baseada no XP acumulado (a cada 100 XP)
+            updateRankingByXP(stats);
 
             saveStats(stats);
         }
@@ -1263,10 +1284,11 @@
                 }
             });
             
-            // Atualizar pontuação
+            // Atualizar pontuação e XP (+50 por acerto)
             if (isCorrect) {
                 score++;
                 document.getElementById('scoreDisplay').textContent = `ACERTOS: ${score}`;
+                addXP(50);
             }
             
             // Mostrar modal de feedback após um pequeno delay

--- a/quiz_portugues.html
+++ b/quiz_portugues.html
@@ -1178,6 +1178,31 @@
             }
         }
 
+        // Free Fire rank mapping and XP helpers
+        const FREE_FIRE_RANKS = [
+            'Bronze I','Bronze II','Bronze III',
+            'Prata I','Prata II','Prata III',
+            'Ouro I','Ouro II','Ouro III','Ouro IV',
+            'Platina I','Platina II','Platina III','Platina IV',
+            'Diamante I','Diamante II','Diamante III','Diamante IV',
+            'Mestre','Desafiante'
+        ];
+
+        function updateRankingByXP(stats) {
+            const currentXP = stats.xp || 0;
+            const rankIndex = Math.min(Math.floor(currentXP / 100), FREE_FIRE_RANKS.length - 1);
+            stats.ranking = FREE_FIRE_RANKS[rankIndex];
+        }
+
+        function addXP(amount) {
+            const stats = loadStats();
+            stats.xp = (stats.xp || 0) + amount;
+            // compat com UI antiga
+            stats.totalScore = (stats.totalScore || 0) + amount;
+            updateRankingByXP(stats);
+            saveStats(stats);
+        }
+
         function updateStatsAfterQuiz(finalCorrect, totalQuestions, elapsedMinutes) {
             const stats = loadStats();
             stats.quizzesCompleted = (stats.quizzesCompleted || 0) + 1;
@@ -1191,11 +1216,8 @@
             stats.currentStreak = passed ? (stats.currentStreak || 0) + 1 : 0;
             stats.bestStreak = Math.max(stats.bestStreak || 0, stats.currentStreak);
 
-            const overallPct = Math.round((stats.overallCorrect || 0) / Math.max(1, (stats.overallTotal || 0)) * 100);
-            if (overallPct >= 90) stats.ranking = 'Lendário';
-            else if (overallPct >= 75) stats.ranking = 'Pro';
-            else if (overallPct >= 50) stats.ranking = 'Intermediário';
-            else stats.ranking = 'Iniciante';
+            // Atualizar patente com base no XP
+            updateRankingByXP(stats);
 
             saveStats(stats);
         }
@@ -1271,16 +1293,22 @@
             if (usedQuestionIndices.length >= questions.length - 10) {
                 usedQuestionIndices = [];
             }
-            
-            // Filtrar questões não usadas
-            const availableQuestions = questions.filter((_, index) => 
-                !usedQuestionIndices.includes(index)
+
+            // Filtrar questões que exigem texto base (e que já foram usadas)
+            const TEXT_BASED_REGEX = /(texto|tirinha)/i;
+            let availableQuestions = questions.filter((q, index) => 
+                !TEXT_BASED_REGEX.test(q.question || '') && !usedQuestionIndices.includes(index)
             );
-            
+
+            // Fallback: se houver menos de 10 após filtro, relaxar filtro para manter 10 questões
+            if (availableQuestions.length < 10) {
+                availableQuestions = questions.filter((_, index) => !usedQuestionIndices.includes(index));
+            }
+
             // Selecionar 10 questões aleatórias das disponíveis
             const shuffled = [...availableQuestions].sort(() => 0.5 - Math.random());
             selectedQuestions = shuffled.slice(0, 10);
-            
+
             // Rastrear índices das questões selecionadas
             selectedIndices = selectedQuestions.map(q => {
                 const index = questions.indexOf(q);
@@ -1391,6 +1419,7 @@
             if (isCorrect) {
                 score++;
                 document.getElementById('scoreDisplay').textContent = `ACERTOS: ${score}`;
+                addXP(50);
             }
             setTimeout(() => {
                 showFeedbackModal(isCorrect, question);


### PR DESCRIPTION
Remove Portuguese questions requiring text passages, add +50 XP per correct answer, and implement Free Fire rank progression.

The lobby display now reflects Free Fire ranks and XP progress, with a rank up every 100 XP.

---
<a href="https://cursor.com/background-agent?bcId=bc-28ba4b4a-3773-44e7-a575-4def02af5b99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28ba4b4a-3773-44e7-a575-4def02af5b99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

