### PR TITLE
Fix math quiz mobile display

### DIFF
--- a/quiz_matematica.html
+++ b/quiz_matematica.html
@@ -262,6 +262,8 @@
             font-weight: 400;
             position: relative;
             z-index: 2;
+            overflow-wrap: anywhere;
+            word-break: normal;
         }
 
         .question-text strong {
@@ -366,6 +368,8 @@
             line-height: 1.5;
             z-index: 2;
             position: relative;
+            overflow-wrap: anywhere;
+            word-break: normal;
         }
 
         /* BUTTONS */
@@ -837,6 +841,7 @@
             
             .nav-controls {
                 display: flex;
+                order: 2;
             }
             
             .back-btn {
@@ -845,12 +850,13 @@
             }
 
             .quiz-container {
-                margin-top: 80px;
+                margin-top: 140px;
             }
 
             .question-container {
                 padding: 1rem;
-                min-height: calc(100vh - 100px);
+                min-height: calc(100vh - 150px);
+                min-height: calc(100dvh - 150px);
             }
             
             .question-card {
@@ -942,11 +948,12 @@
             }
             
             .quiz-container {
-                margin-top: 70px;
+                margin-top: 160px;
             }
 
             .question-container {
-                min-height: calc(100vh - 80px);
+                min-height: calc(100vh - 170px);
+                min-height: calc(100dvh - 170px);
                 padding: 0.5rem;
             }
             


### PR DESCRIPTION
Adjust `quiz_matematica.html` CSS to improve responsiveness on mobile screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-faf071ee-746c-49c4-b6aa-570f7bc39205">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-faf071ee-746c-49c4-b6aa-570f7bc39205">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

